### PR TITLE
Revert "Update dependency autoprefixer to v10.4.20"

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@vueuse/components": "^10.11.0",
     "@vueuse/core": "^10.11.0",
     "@vueuse/nuxt": "^10.11.0",
-    "autoprefixer": "^10.4.19",
+    "autoprefixer": "^10.4.17",
     "dayjs-nuxt": "^2.1.9",
     "eslint": "^8.57.0",
     "happy-dom": "^14.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         specifier: ^10.11.0
         version: 10.11.0(magicast@0.3.4)(nuxt@3.8.1(@parcel/watcher@2.4.1)(@types/node@20.14.12)(eslint@8.57.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.18.1)(terser@5.31.2)(typescript@5.5.4)(vite@4.5.3(@types/node@20.14.12)(terser@5.31.2)))(rollup@4.18.1)(vue@3.4.31(typescript@5.5.4))
       autoprefixer:
-        specifier: ^10.4.19
+        specifier: ^10.4.17
         version: 10.4.19(postcss@8.4.39)
       dayjs-nuxt:
         specifier: ^2.1.9
@@ -5657,9 +5657,6 @@ packages:
   unimport@3.8.0:
     resolution: {integrity: sha512-leq5bfNxyytAer8cYPi0dR0L6p8ZnZ8NxR9TKsSIbJM47TOxC5qURJXQZ8xuBGqLakUqYO6CvVtf3lWKo9k+8A==}
 
-  unimport@3.9.0:
-    resolution: {integrity: sha512-H2ftTISja1BonUVdOKRos6HC6dqYDR40dQTZY3zIDJ/5/z4ihncuL0LqLvtxYqUDMib41eAtunQUhXIWTCZ8rA==}
-
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
@@ -7270,7 +7267,7 @@ snapshots:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.9.0(rollup@4.18.1)
+      unimport: 3.10.0(rollup@4.18.1)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -7374,7 +7371,7 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.9.0(rollup@4.18.1)
+      unimport: 3.10.0(rollup@4.18.1)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -9056,7 +9053,7 @@ snapshots:
 
   dayjs-nuxt@2.1.9(magicast@0.3.4)(rollup@4.18.1):
     dependencies:
-      '@nuxt/kit': 3.12.3(magicast@0.3.4)(rollup@4.18.1)
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.18.1)
       dayjs: 1.11.11
     transitivePeerDependencies:
       - magicast
@@ -12924,24 +12921,6 @@ snapshots:
       scule: 1.3.0
       strip-literal: 2.1.0
       unplugin: 1.11.0
-    transitivePeerDependencies:
-      - rollup
-
-  unimport@3.9.0(rollup@4.18.1):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
-      acorn: 8.12.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.1.3
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.12.0
     transitivePeerDependencies:
       - rollup
 


### PR DESCRIPTION
This reverts commit 65d6cc9daa6c2ddc6a43727dcf6fadadfe403964.